### PR TITLE
Require all of activesupport.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "sinatra"
+gem "activesupport", require: "active_support"
 gem "mongo_mapper"
 gem "bson_ext"
 gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   bson_ext
   dotenv
   json
   minitest
   mongo_mapper
   sinatra
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Fixes https://github.com/kdaigle/hookable/issues/1

@kdaigle, this seems to have fixed the activesupport loading issue. It appears that loading core extensions (as mongomapper does) requires that you require the entire gem first (source: https://github.com/rails/rails/issues/14664#issuecomment-40191673).

Can't confirm that all runs perfectly, however, because my instance isn't able to authenticate with my MongoLab instance, though I can just fine via the `mongo` shell. Curious!
